### PR TITLE
numeric size legend

### DIFF
--- a/src/components/dst-legend.tsx
+++ b/src/components/dst-legend.tsx
@@ -17,10 +17,6 @@ import { NumericSizeLegend } from "./legend/numeric-size-legend";
 
 import "./dst-legend.scss";
 
-// function UnsupportedNumericSize() {
-//   return <text>Numeric attributes do not have a size legend yet</text>;
-// }
-
 const sizeLegendComponentMap: Partial<Record<string, React.ComponentType<IBaseLegendProps>>> = {
   categorical: CategoricalSizeLegend,
   numeric: NumericSizeLegend

--- a/src/components/dst-legend.tsx
+++ b/src/components/dst-legend.tsx
@@ -7,11 +7,13 @@ import { ITileSelection, TileSelectionContext } from "../codap/hooks/use-tile-se
 import { DataDisplayLayoutContext } from "../codap/components/data-display/hooks/use-data-display-layout";
 import { DataDisplayLayout } from "../codap/components/data-display/models/data-display-layout";
 import { legendComponentManager } from "../codap/components/data-display/components/legend/legend";
+import { IBaseLegendProps } from "../codap/components/data-display/components/legend/legend-common";
 import { dstContainer } from "../models/dst-container";
-import { IDstDataConfigurationModel } from "../models/dst-data-display-model";
+import { IDstDataConfigurationModel } from "../models/dst-data-configuration-model";
 import { kInitialDimensions } from "../utilities/constants";
 import { CategoricalSizeLegend } from "./legend/categorical-size-legend";
 import { DstMultiLegend } from "./legend/dst-multi-legend";
+import { NumericSizeLegend } from "./legend/numeric-size-legend";
 
 import "./dst-legend.scss";
 
@@ -19,12 +21,20 @@ import "./dst-legend.scss";
 //   return <text>Numeric attributes do not have a size legend yet</text>;
 // }
 
-// register our new legend
+const sizeLegendComponentMap: Partial<Record<string, React.ComponentType<IBaseLegendProps>>> = {
+  categorical: CategoricalSizeLegend,
+  numeric: NumericSizeLegend
+};
+
+// register our new legends
 legendComponentManager.getLegendComponent = (dataConfig) => {
   const type = dataConfig.attributeType("legend");
   const representation = (dataConfig as IDstDataConfigurationModel).legendRepresentation;
 
-  if (representation === "size" && type === "categorical") return CategoricalSizeLegend;
+  if (representation === "size" && type) {
+    const component = sizeLegendComponentMap[type];
+    if (component) return component;
+  }
 
   // If the representation is size by the type is numeric or date then the result is currently
   // broken. The legend will show as color numeric legend. But the points will get rendered

--- a/src/components/legend/categorical-size-legend.tsx
+++ b/src/components/legend/categorical-size-legend.tsx
@@ -7,7 +7,7 @@ import { useDataDisplayLayout } from "../../codap/components/data-display/hooks/
 import { mstReaction } from "../../codap/utilities/mst-reaction";
 import { axisGap } from "../../codap/components/axis/axis-types";
 import { mstAutorun } from "../../codap/utilities/mst-autorun";
-import { IDstDataConfigurationModel } from "../../models/dst-data-display-model";
+import { IDstDataConfigurationModel } from "../../models/dst-data-configuration-model";
 
 import "./size-legend.scss";
 

--- a/src/components/legend/categorical-size-legend.tsx
+++ b/src/components/legend/categorical-size-legend.tsx
@@ -1,6 +1,6 @@
 import {drag, select} from "d3";
 import React, {useCallback, useEffect, useMemo, useRef, useState} from "react";
-import { CategoricalSizeLegendModel, labelHeight, Key } from "./categorical-size-model";
+import { CategoricalSizeLegendModel, labelHeight, CategoricalSizeLegendKey } from "./categorical-size-model";
 import { IBaseLegendProps } from "../../codap/components/data-display/components/legend/legend-common";
 import { useDataConfigurationContext } from "../../codap/components/data-display/hooks/use-data-configuration-context";
 import { useDataDisplayLayout } from "../../codap/components/data-display/hooks/use-data-display-layout";
@@ -61,7 +61,7 @@ export const CategoricalSizeLegend =
       };
     }, [layerIndex, setDesiredExtent]);
 
-    const handleLegendKeyClick = useCallback((event: any, d: Key) => {
+    const handleLegendKeyClick = useCallback((event: any, d: CategoricalSizeLegendKey) => {
       const caseIds = dataConfiguration?.getCasesForLegendValue(d.category);
       if (caseIds) {
         // This is breaking the graph-legend cypress test
@@ -73,19 +73,19 @@ export const CategoricalSizeLegend =
 
     // The dragBehavior is created first, so d3Render can add this to all new elements.
     const dragBehavior = useMemo(() => {
-      const onDragStart = (event: { x: number; y: number }, d: Key) => {
+      const onDragStart = (event: { x: number; y: number }, d: CategoricalSizeLegendKey) => {
         legendModel.onDragStart(event, d);
       };
 
-      const onDrag = (event: { dx: number; dy: number }, d: Key) => {
+      const onDrag = (event: { dx: number; dy: number }, d: CategoricalSizeLegendKey) => {
         legendModel.onDrag(event, d);
       };
 
-      const onDragEnd = (event: any, d: Key) => {
+      const onDragEnd = (event: any, d: CategoricalSizeLegendKey) => {
         legendModel.onDragEnd(dataConfiguration, d);
       };
 
-      return drag<SVGGElement, Key>()
+      return drag<SVGGElement, CategoricalSizeLegendKey>()
         .on("start", onDragStart)
         .on("drag", onDrag)
         .on("end", onDragEnd);
@@ -97,7 +97,7 @@ export const CategoricalSizeLegend =
       const keySize = legendModel.categoryCircleMaxDiameter;
 
       const keysSelection = select(keysElt.current)
-        .selectAll<SVGGElement, Key>("g")
+        .selectAll<SVGGElement, CategoricalSizeLegendKey>("g")
         .data(legendModel.categoryData, d => d.category)
         .join(
           (enter) => {

--- a/src/components/legend/categorical-size-model.ts
+++ b/src/components/legend/categorical-size-model.ts
@@ -10,7 +10,7 @@ import { measureText } from "../../codap/hooks/use-measure-text";
 import { logMessageWithReplacement } from "../../codap/lib/log-message";
 import { defaultPointDiameter, IDstDataConfigurationModel } from "../../models/dst-data-configuration-model";
 
-export interface Key {
+export interface CategoricalSizeLegendKey {
   category: string;
   size: number;
   index: number;
@@ -124,7 +124,7 @@ export class CategoricalSizeLegendModel {
     return catIndex >= 0 && catIndex < this.numCategories ? catIndex : -1;
   }
 
-  catLocation(categoryKey: Key) {
+  catLocation(categoryKey: CategoricalSizeLegendKey) {
     return {
       x: axisGap + categoryKey.column * this.layoutData.columnWidth,
       y: categoryKey.row * this.layoutData.rowHeight
@@ -155,7 +155,7 @@ export class CategoricalSizeLegendModel {
     }));
   }
 
-  onDragStart(event: { x: number; y: number; }, d: Key) {
+  onDragStart(event: { x: number; y: number; }, d: CategoricalSizeLegendKey) {
     const localPt = {
       x: event.x,
       y: event.y - labelHeight
@@ -179,7 +179,7 @@ export class CategoricalSizeLegendModel {
     dI.currentIndex = d.index;
   }
 
-  onDrag(event: { dx: number; dy: number; }, d: Key) {
+  onDrag(event: { dx: number; dy: number; }, d: CategoricalSizeLegendKey) {
     if (event.dx !== 0 || event.dy !== 0) {
       const dI = this.dragInfo;
 
@@ -197,7 +197,7 @@ export class CategoricalSizeLegendModel {
   }
 
   onDragEnd(
-    dataConfiguration: IDataConfigurationModel | undefined, d: Key
+    dataConfiguration: IDataConfigurationModel | undefined, d: CategoricalSizeLegendKey
   ) {
     const categories = dataConfiguration?.categoryArrayForAttrRole("legend") || [];
     const dI = this.dragInfo;

--- a/src/components/legend/categorical-size-model.ts
+++ b/src/components/legend/categorical-size-model.ts
@@ -8,7 +8,7 @@ import { IDataConfigurationModel } from "../../codap/components/data-display/mod
 import { kDataDisplayFont, kMain } from "../../codap/components/data-display/data-display-types";
 import { measureText } from "../../codap/hooks/use-measure-text";
 import { logMessageWithReplacement } from "../../codap/lib/log-message";
-import { defaultPointDiameter, IDstDataConfigurationModel } from "../../models/dst-data-display-model";
+import { defaultPointDiameter, IDstDataConfigurationModel } from "../../models/dst-data-configuration-model";
 
 export interface Key {
   category: string;

--- a/src/components/legend/numeric-size-legend-model.ts
+++ b/src/components/legend/numeric-size-legend-model.ts
@@ -1,0 +1,95 @@
+import { makeAutoObservable } from "mobx";
+
+import vars from "../../codap/components/vars.scss";
+import { getStringBounds } from "../../codap/components/axis/axis-utils";
+import { DataDisplayLayout } from "../../codap/components/data-display/models/data-display-layout";
+import { IDstDataConfigurationModel } from "../../models/dst-data-configuration-model";
+
+export interface Key {
+  size: number;
+  index: number;
+  canonicalValue: number;
+  min: number;
+  max: number;
+}
+interface Layout {
+  fullWidth: number;
+  numColumns: number;
+  rowHeight: number;
+}
+
+export const padding = 5;
+// Because the points start small, we can gain back some height by squeezing the 
+// the points up into the axis label area.
+export const labelHeight = getStringBounds("Wy", vars.labelFont).height - 5;
+
+// TODO: try extending the CategoryLegendModel
+// we have to understand what works and what doesn't work with MobX sub classing
+export class NumericSizeLegendModel {
+  dataDisplayLayout: DataDisplayLayout;
+  dataConfiguration: IDstDataConfigurationModel | undefined;
+
+  constructor(dataConfiguration: IDstDataConfigurationModel | undefined, dataDisplayLayout: DataDisplayLayout) {
+    this.dataDisplayLayout = dataDisplayLayout;
+    this.dataConfiguration = dataConfiguration;
+    makeAutoObservable(this);
+  }
+
+  setDataConfiguration(dataConfiguration: IDstDataConfigurationModel | undefined) {
+    this.dataConfiguration = dataConfiguration;
+  }
+
+  setDataDisplayLayout(dataDisplayLayout: DataDisplayLayout) {
+    this.dataDisplayLayout = dataDisplayLayout;
+  }
+
+  get pointValues () {
+    const quantizedScale = this.dataConfiguration?.numericSizeScale;
+    if (!quantizedScale) {
+      console.warn("pointsData: no scale found");
+      return [];
+    }
+
+    return quantizedScale.range();
+  }
+
+  get ticks() {
+    return this.dataConfiguration?.numericSizeTicks || [];
+  }
+
+  get pointsData(): Key[] {
+    if (this.ticks.length < 2) return [];
+    const halfStep = (this.ticks[1] - this.ticks[0]) / 2;
+
+    return this.pointValues.map((size, index) => ({
+      size,
+      index,
+      canonicalValue: this.ticks[index] + halfStep,
+      min: index === 0 ? -Infinity : this.ticks[index],
+      max: index === this.pointValues.length - 1 ? Infinity : this.ticks[index+1]
+    }));
+  }
+
+  get circleMaxDiameter() {
+    const { pointValues } = this;
+
+    if (pointValues.length < 1) return 0;
+
+    return pointValues[pointValues.length - 1];
+  }
+
+  get layoutData() {
+    const fullWidth = this.dataDisplayLayout.tileWidth;
+    const rowHeight = this.circleMaxDiameter + padding;
+    const numColumns = this.pointValues.length || 1;
+
+    const lod: Layout = {
+      fullWidth,
+      numColumns,
+      rowHeight
+    };
+
+    return lod;
+  }
+
+}

--- a/src/components/legend/numeric-size-legend-model.ts
+++ b/src/components/legend/numeric-size-legend-model.ts
@@ -5,14 +5,14 @@ import { getStringBounds } from "../../codap/components/axis/axis-utils";
 import { DataDisplayLayout } from "../../codap/components/data-display/models/data-display-layout";
 import { IDstDataConfigurationModel } from "../../models/dst-data-configuration-model";
 
-export interface Key {
+export interface NumericSizeLegendKey {
   size: number;
   index: number;
   canonicalValue: number;
   min: number;
   max: number;
 }
-interface Layout {
+interface NumericSizeLegendLayout {
   fullWidth: number;
   numColumns: number;
   rowHeight: number;
@@ -57,7 +57,7 @@ export class NumericSizeLegendModel {
     return this.dataConfiguration?.numericSizeTicks || [];
   }
 
-  get pointsData(): Key[] {
+  get pointsData(): NumericSizeLegendKey[] {
     if (this.ticks.length < 2) return [];
     const halfStep = (this.ticks[1] - this.ticks[0]) / 2;
 
@@ -83,7 +83,7 @@ export class NumericSizeLegendModel {
     const rowHeight = this.circleMaxDiameter + padding;
     const numColumns = this.pointValues.length || 1;
 
-    const lod: Layout = {
+    const lod: NumericSizeLegendLayout = {
       fullWidth,
       numColumns,
       rowHeight

--- a/src/components/legend/numeric-size-legend.tsx
+++ b/src/components/legend/numeric-size-legend.tsx
@@ -6,7 +6,7 @@ import { useDataDisplayLayout } from "../../codap/components/data-display/hooks/
 import { mstReaction } from "../../codap/utilities/mst-reaction";
 import { mstAutorun } from "../../codap/utilities/mst-autorun";
 import { IDstDataConfigurationModel } from "../../models/dst-data-configuration-model";
-import { NumericSizeLegendModel, labelHeight, Key } from "./numeric-size-legend-model";
+import { NumericSizeLegendModel, labelHeight, NumericSizeLegendKey } from "./numeric-size-legend-model";
 
 import "./size-legend.scss";
 
@@ -38,7 +38,8 @@ export const NumericSizeLegend =
           }
           // There is just one row so this is a basic calculation
           // We are just hacking the height of the axis for now
-          return labelHeight + legendModel.layoutData.rowHeight + 20;
+          const axisHeight = 20;
+          return labelHeight + legendModel.layoutData.rowHeight + axisHeight;
         },
         (desiredExtent) => {
           setDesiredExtent(layerIndex, desiredExtent);
@@ -60,7 +61,7 @@ export const NumericSizeLegend =
       };
     }, [layerIndex, setDesiredExtent]);
 
-    const handleLegendKeyClick = useCallback((event: any, d: Key) => {
+    const handleLegendKeyClick = useCallback((event: any, d: NumericSizeLegendKey) => {
       const caseIds = dataConfiguration?.getCasesForLegendRange(d.min, d.max);
       if (caseIds) {
         if (event.shiftKey) dataConfiguration?.dataset?.selectCases(caseIds);
@@ -75,7 +76,7 @@ export const NumericSizeLegend =
 
       const keysSelection = select(keysElt.current)
         .select(".legend-size-numeric-points")
-        .selectAll<SVGGElement, Key>("circle")
+        .selectAll<SVGGElement, NumericSizeLegendKey>("circle")
         .data(legendModel.pointsData)
         .join(
           (enter) => {

--- a/src/components/legend/numeric-size-legend.tsx
+++ b/src/components/legend/numeric-size-legend.tsx
@@ -1,0 +1,123 @@
+import {axisBottom, scaleLinear, select} from "d3";
+import React, {useCallback, useEffect, useRef, useState} from "react";
+import { IBaseLegendProps } from "../../codap/components/data-display/components/legend/legend-common";
+import { useDataConfigurationContext } from "../../codap/components/data-display/hooks/use-data-configuration-context";
+import { useDataDisplayLayout } from "../../codap/components/data-display/hooks/use-data-display-layout";
+import { mstReaction } from "../../codap/utilities/mst-reaction";
+import { mstAutorun } from "../../codap/utilities/mst-autorun";
+import { IDstDataConfigurationModel } from "../../models/dst-data-configuration-model";
+import { NumericSizeLegendModel, labelHeight, Key } from "./numeric-size-legend-model";
+
+import "./size-legend.scss";
+
+const margin = 30;
+
+// This is not an observing component because all of its real rendering happens in
+// a mstAutorun.
+export const NumericSizeLegend =
+  function NumericSizeLegend({layerIndex, setDesiredExtent}: IBaseLegendProps) {
+
+    const dataConfiguration = useDataConfigurationContext() as IDstDataConfigurationModel;
+    const dataDisplayLayout = useDataDisplayLayout();
+    const keysElt = useRef(null);
+
+    // useState guarantees the model will only be created once
+    // useMemo doesn't have that guarantee
+    const [legendModel] = useState(
+      () => new NumericSizeLegendModel(dataConfiguration, dataDisplayLayout)
+    );
+
+    // This is outside of the main autorun because setDesiredExtent might 
+    // cause extra re-renders, so it only
+    // runs when the desiredExtent actually changes
+    useEffect(function updateDesiredExtent() {
+      return mstReaction(
+        () => {
+          if (dataConfiguration?.placeCanHaveZeroExtent("legend")) {
+            return 0;
+          }
+          // There is just one row so this is a basic calculation
+          // We are just hacking the height of the axis for now
+          return labelHeight + legendModel.layoutData.rowHeight + 20;
+        },
+        (desiredExtent) => {
+          setDesiredExtent(layerIndex, desiredExtent);
+        },
+        {name: "NumericSizeLegend updateDesiredExtent", fireImmediately: true},
+        dataConfiguration
+      );
+    }, [dataConfiguration, setDesiredExtent, layerIndex, legendModel]);
+
+    // These variables should not change, but theoretically it is possible
+    useEffect(function updateContextVariables() {
+      legendModel.setDataConfiguration(dataConfiguration);
+      legendModel.setDataDisplayLayout(dataDisplayLayout);
+    }, [dataConfiguration, dataDisplayLayout, legendModel]);
+
+    useEffect(() => {
+      return function cleanup() {
+        setDesiredExtent(layerIndex, 0);
+      };
+    }, [layerIndex, setDesiredExtent]);
+
+    const handleLegendKeyClick = useCallback((event: any, d: Key) => {
+      const caseIds = dataConfiguration?.getCasesForLegendRange(d.min, d.max);
+      if (caseIds) {
+        if (event.shiftKey) dataConfiguration?.dataset?.selectCases(caseIds);
+        else dataConfiguration?.dataset?.setSelectedCases(caseIds);
+      }
+    }, [dataConfiguration]);
+
+    useEffect(() => { return mstAutorun(function d3Render() {
+      if (!keysElt.current) return;
+
+      const keySize = legendModel.circleMaxDiameter;
+
+      const keysSelection = select(keysElt.current)
+        .select(".legend-size-numeric-points")
+        .selectAll<SVGGElement, Key>("circle")
+        .data(legendModel.pointsData)
+        .join(
+          (enter) => {
+            return enter.append("circle")
+              .attr("class", "legend-key")
+              .attr("data-testid", "legend-key")
+              .on("click", handleLegendKeyClick);
+          }
+        );
+
+      const ticks = legendModel.ticks;
+      if (ticks.length < 2) {
+        console.warn("Not enough ticks");
+        return;
+      }
+      const firstTick = ticks[0];
+      const lastTick = ticks[ticks.length-1];
+      const axisScale = scaleLinear([firstTick, lastTick], [margin, legendModel.layoutData.fullWidth - margin*2]);
+  
+      keysSelection
+        .attr("r", d => d.size/2)
+        .attr("cx", d => axisScale(d.canonicalValue))
+        .attr("cy", labelHeight + keySize/2)
+        .classed("legend-key-selected", (d) => {
+          return dataConfiguration?.casesInRangeAreSelected(d.min, d.max) ?? false;
+        });
+      
+      const axis = axisBottom(axisScale).ticks(ticks.length);
+
+      select(keysElt.current)
+        .selectAll<SVGGElement, any>(".legend-size-numeric-axis")
+        .call(axis)
+        .attr("transform", `translate(0 ${labelHeight + legendModel.layoutData.rowHeight})`);
+
+    }, {name: "NumericSizeLegend d3 render"}, dataConfiguration); },
+      [dataConfiguration, handleLegendKeyClick, legendModel]
+    );
+
+    return (
+      <g ref={keysElt} className="legend-size-numeric" data-testid="legend-size-numeric">
+        <g className="legend-size-numeric-points"></g>
+        <g className="legend-size-numeric-axis"></g>
+      </g>
+    );
+  };

--- a/src/components/plot/point.tsx
+++ b/src/components/plot/point.tsx
@@ -18,8 +18,8 @@ export const Point = observer(function Point({ id, visible, x, y, z }: IPointPro
   const [isPointerOver, setPointerOver] = useState(false);
   
   // TODO: these configs might be undefined
-  const colorDataConfig = dstContainer.dataDisplayModel.layers[0].dataConfiguration;
-  const sizeDataConfig = dstContainer.dataDisplayModel.layers[1].dataConfiguration;
+  const colorDataConfig = dstContainer.dataDisplayModel.colorDataConfiguration;
+  const sizeDataConfig = dstContainer.dataDisplayModel.sizeDataConfiguration;
   
   // The default color from the spec is: "#e6805bd9" (RGBA)
   // Note: If there is no value for the attribute on this case getLegendColorForCase(id) 

--- a/src/models/dst-data-configuration-model.ts
+++ b/src/models/dst-data-configuration-model.ts
@@ -96,8 +96,8 @@ export const DstDataConfigurationModel = DataConfigurationModel.named("DstDataCo
   }))
   .views(self => ({
     casesInRangeAreSelected(min: number, max: number): boolean {
-      const selection = self.getCasesForLegendRange(min, max);
-      return !!(selection.length > 0 && selection?.every((anID: string) => self.dataset?.isCaseSelected(anID)));
+      const casesInRange = self.getCasesForLegendRange(min, max);
+      return !!(casesInRange.length > 0 && casesInRange?.every((anID: string) => self.dataset?.isCaseSelected(anID)));
     },
     getLegendSizeForCase(id: string) {
       const legendID = self.attributeID("legend");

--- a/src/models/dst-data-configuration-model.ts
+++ b/src/models/dst-data-configuration-model.ts
@@ -1,0 +1,129 @@
+import { extent, nice, ticks, scalePoint, scaleQuantize, range } from "d3";
+import { types, Instance } from "mobx-state-tree";
+import { DataConfigurationModel } from "../codap/components/data-display/models/data-configuration-model";
+import { CaseData } from "../codap/components/data-display/d3-types";
+import { dataDisplayGetNumericValue } from "../codap/components/data-display/data-display-value-utils";
+
+// These are diameters
+const minDiameter = 3;
+const maxDiameter = 21;
+
+// The spec has this at 12, but it is little big with our default data
+export const defaultPointDiameter = 9;
+
+export const DstDataConfigurationModel = DataConfigurationModel.named("DstDataConfiguration")
+  .props({
+    legendRepresentation: types.maybe(types.enumeration(["color", "size"]))
+  })
+  .views(self => ({
+    get numericSizeTicks() {
+      const attrID = self.attributeID("legend");
+      if (!attrID) return [];
+
+      const dataset = self.dataset;
+      if (!dataset) return [];
+
+      const attr = dataset.getAttribute(attrID);
+      if (!attr) return [];
+
+      // We read the changeCount so this function is responsive if the values change
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      attr.changeCount;
+      const [realFirst, realLast] = extent(attr.numValues);
+      if (realFirst == null || realLast == null) return [];
+
+      const [niceFirst, niceLast] = nice(realFirst, realLast, 6);
+
+      return ticks(niceFirst, niceLast, 5);
+    }
+  }))
+  .views(self => ({
+    get categoricalSizeScale() {
+      // This will return an array of [kMain] if there is no legend
+      const categories = self.categoryArrayForAttrRole("legend");
+
+      return scalePoint(categories, [minDiameter, maxDiameter])
+        // Make single categories have the default point size
+        // Note: If we added padding to the scale this alignment would 
+        // affect other sizes too, but without padding the alignment
+        // only applies when there is a single point.
+        // TODO: perhaps when there are 2 categories we don't want default to be the
+        // min and max diameters? That will require a more complex scale 
+        .align((defaultPointDiameter-minDiameter)/(maxDiameter-minDiameter));
+    },
+
+    get numericSizeScale() {
+      const binTicks = self.numericSizeTicks;
+
+      if (binTicks.length < 2) return scaleQuantize();
+
+      const niceFirst = binTicks[0];
+      const niceLast = binTicks[binTicks.length - 1];
+
+      // We need an array of values ranging from minDiameter to maxDiameter
+      // and the count of them should be binTicks.length - 1
+      const numBins = binTicks.length - 1;
+      const step = (maxDiameter - minDiameter) / (numBins - 1);
+
+      // d3.range excludes the stop value so we need to add step to it.
+      // With rounding errors the maxDiameter plus the step might be bigger
+      // than the last value d3 computes so just be sure we go a little less 
+      // than the step.
+      const pointValues = range(minDiameter, maxDiameter + (step * 0.9), step);
+
+      return scaleQuantize([niceFirst, niceLast], pointValues);
+    }
+  }))
+  .views(self => ({
+    getLegendSizeForCategory(category: string) {
+      return self.categoricalSizeScale(category) ?? defaultPointDiameter;
+    },
+    getLegendSizeForNumericValue(value: number) {
+      return self.numericSizeScale(value) ?? defaultPointDiameter;
+    },
+    // This is a generic function which could be also be used by 
+    // getCasesForLegendQuantile.
+    getCasesForLegendRange(min: number, max: number) {
+      const dataset = self.dataset,
+        legendID = self.attributeID("legend");
+      return legendID
+        ? self.getCaseDataArray(0).filter((aCaseData: CaseData) => {
+          const value = dataDisplayGetNumericValue(dataset, aCaseData.caseID, legendID);
+          return value !== undefined && value >= min && value < max;
+        }).map((aCaseData: CaseData) => aCaseData.caseID)
+        : [];
+    }
+  }))
+  .views(self => ({
+    casesInRangeAreSelected(min: number, max: number): boolean {
+      const selection = self.getCasesForLegendRange(min, max);
+      return !!(selection.length > 0 && selection?.every((anID: string) => self.dataset?.isCaseSelected(anID)));
+    },
+    getLegendSizeForCase(id: string) {
+      const legendID = self.attributeID("legend");
+      const legendAttribute = self.dataset?.getAttribute(legendID);
+      if (!id || !legendID || !legendAttribute) {
+        return defaultPointDiameter;
+      }
+
+      const legendType = self.attributeType("legend");
+      switch (legendType) {
+        case "categorical": {
+          const legendValue = self.dataset?.getStrValue(id, legendID);
+          if (!legendValue) return defaultPointDiameter;
+          return self.getLegendSizeForCategory(legendValue);
+        }
+        case "numeric": {
+          const legendValue = self.dataset?.getNumeric(id, legendID);
+          if (legendValue == null) return defaultPointDiameter;
+          return self.getLegendSizeForNumericValue(legendValue);
+        }
+        case "date":
+        case "color":
+        default:
+          return defaultPointDiameter;
+      }
+    }
+  }));
+
+export interface IDstDataConfigurationModel extends Instance<typeof DstDataConfigurationModel> { }

--- a/src/models/dst-data-display-model.ts
+++ b/src/models/dst-data-display-model.ts
@@ -12,6 +12,14 @@ export const DstLayerModel = types.model("DstLayerModel", {
 export const DstDataDisplayModel = types.model("DstDataDisplayModel", {
   layers: types.array(DstLayerModel)
 })
+.views(self => ({
+  get colorDataConfiguration() {
+    return self.layers[0].dataConfiguration;
+  },
+  get sizeDataConfiguration() {
+    return self.layers[1].dataConfiguration;
+  }
+}))
 .actions(self => ({
   placeCanAcceptAttributeIDDrop(place: GraphPlace,
     dataset: IDataSet | undefined,

--- a/src/models/dst-data-display-model.ts
+++ b/src/models/dst-data-display-model.ts
@@ -1,54 +1,7 @@
-import { Instance, types } from "mobx-state-tree";
-import { DataConfigurationModel } from "../codap/components/data-display/models/data-configuration-model";
+import { types } from "mobx-state-tree";
 import { GraphPlace } from "../codap/components/axis-graph-shared";
 import { IDataSet } from "../codap/models/data/data-set";
-import { scalePoint } from "d3";
-
-// These are diameters
-const minDiameter = 3;
-const maxDiameter = 21;
-export const defaultPointDiameter = 12;
-
-export const DstDataConfigurationModel = DataConfigurationModel.named("DstDataConfiguration")
-.props({
-  legendRepresentation: types.maybe(types.enumeration(["color", "size"]))
-})
-.views(self => ({
-  get categoricalSizeScale() {
-    const categorySet = self.categorySetForAttrRole("legend");
-
-    // Just use the default size
-    if (!categorySet) return (value: string) => undefined;
-    // I think there's a helper function for this in dataConfiguration
-    const categories = categorySet.values;
-
-    return scalePoint(categories, [minDiameter, maxDiameter]);
-  }
-}))
-.views(self => ({
-  getLegendSizeForCategory(category: string) {
-    return self.categoricalSizeScale(category) ?? defaultPointDiameter;
-  }
-}))
-.views(self => ({
-  getLegendSizeForCase(id: string) {
-    const legendID = self.attributeID("legend");
-    // todo: When user deletes we are not currently deleting the legend attribute ID. But we should.
-    const legendAttribute = self.dataset?.getAttribute(legendID);
-    if (!id || !legendID || !legendAttribute) {
-      return defaultPointDiameter;
-    }
-    // Assume it is categorical for now
-    // const legendType = self.attributeType("legend")
-    const legendValue = self.dataset?.getStrValue(id, legendID);
-    if (!legendValue) return defaultPointDiameter;
-
-    return self.getLegendSizeForCategory(legendValue);
-  }
-}));
-
-export interface IDstDataConfigurationModel extends Instance<typeof DstDataConfigurationModel> {}
-
+import { DstDataConfigurationModel } from "./dst-data-configuration-model";
 
 export const DstLayerModel = types.model("DstLayerModel", {
   layerIndex: types.number,

--- a/src/utilities/codap-utils.ts
+++ b/src/utilities/codap-utils.ts
@@ -155,14 +155,14 @@ export function updateDataSetAttributes(dataContext: DIDataContext) {
   
   if (!colorAttribute || !sizeAttribute || !latAttribute || !longAttribute) return;
 
-  const colorConfiguration = dstContainer.dataDisplayModel.layers[0].dataConfiguration;
+  const colorConfiguration = dstContainer.dataDisplayModel.colorDataConfiguration;
   colorConfiguration.setAttribute("legend", {
     attributeID: colorAttribute.id,
   });
   colorConfiguration.setAttribute("x", {attributeID: longAttribute.id});
   colorConfiguration.setAttribute("y", {attributeID: latAttribute.id});
 
-  const sizeConfiguration = dstContainer.dataDisplayModel.layers[1].dataConfiguration;
+  const sizeConfiguration = dstContainer.dataDisplayModel.sizeDataConfiguration;
   sizeConfiguration.setAttribute("legend", {
     attributeID: sizeAttribute.id,
   });
@@ -175,10 +175,13 @@ export function setDSTCases(cases: ICaseCreation[]) {
   const dstDataset = dstContainer.dataSet;
   dstDataset.removeCases(dstDataset.itemIds);
   dstDataset.addCases(cases, {canonicalize: true});
-  const configuration = dstContainer.dataDisplayModel.layers[0].dataConfiguration;
-  
-  // For the configuration to refresh, the following functions have to be called.
-  // This might show up as a problem with undo/redo as well.
-  configuration._clearFilteredCases(configuration.dataset);
-  configuration.clearCasesCache();
+
+  dstContainer.dataDisplayModel.layers.forEach(layer => {
+    const configuration = layer.dataConfiguration;
+
+    // For the configuration to refresh, the following functions have to be called.
+    // This might show up as a problem with undo/redo as well.
+    configuration._clearFilteredCases(configuration.dataset);
+    configuration.clearCasesCache();
+  });  
 }

--- a/src/utilities/codap-utils.ts
+++ b/src/utilities/codap-utils.ts
@@ -149,7 +149,7 @@ export function updateDataSetAttributes(dataContext: DIDataContext) {
   applySnapshot(dstCaseMetadata, metadataSnapshot);
 
   const colorAttribute = dstDataset.getAttributeByName("Magnitude (0-5)");
-  const sizeAttribute = dstDataset.getAttributeByName("Magnitude (0-5)");
+  const sizeAttribute = dstDataset.getAttributeByName("Injuries");
   const latAttribute = dstDataset.getAttributeByName("Latitude");
   const longAttribute = dstDataset.getAttributeByName("Longitude");
   


### PR DESCRIPTION
This adds a new numeric size legend. So now if you select a numeric attribute in the second legend of the DST plugin you will get points sized by that numeric attribute.

As designed, this isn't a continuous size scale. The points are divided into around 5 equally spaced bins. If the range of values doesn't work well with 5 bins then 4 or 6 bins will be used instead. This is using d3's tick mark logic. 

The selection is based on the points with values that are >= the lower tick and < the upper tick. The exception is the bin on the far right. In this case the upper tick values are included.