### PR TITLE
feat: add deployment link to Jira (START-1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,6 @@ jobs:
       - build_test
       - cypress
     runs-on: ubuntu-latest
-    environment:
-      name: ${{ github.ref_type == 'branch' && 'branches' || 'versions' }}
-      url: https://codap3.concord.org/branch/main/?di=https://models-resources.concord.org/dst-codap-plugin/${{ steps.s3-deploy.outputs.deployPath }}/index.html
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
           prefix: dst-codap-plugin
           awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
           awsSecretAccessKey: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          deployRunUrl: https://models-resources.concord.org/dst-codap-plugin/__deployPath__/index.html
           # Parameters to GHActions have to be strings, so a regular yaml array cannot
           # be used. Instead the `|` turns the following lines into a string
           topBranches: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
           awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
           awsSecretAccessKey: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-          deployRunUrl: https://models-resources.concord.org/dst-codap-plugin/__deployPath__/index.html
+          deployRunUrl: https://codap3.concord.org/branch/main/?di=https://models-resources.concord.org/dst-codap-plugin/__deployPath__/index.html
           # Parameters to GHActions have to be strings, so a regular yaml array cannot
           # be used. Instead the `|` turns the following lines into a string
           topBranches: |


### PR DESCRIPTION
Add `githubToken` and `deployRunUrl` to `.github/workflows/ci.yml`. This will allow the new version of `s3-deploy-action` to create a GitHub Deployment and set its `log_url` property, which will allow Jira to add a deployment link to associated Jira issues.