### PR TITLE
Switch S3 deployment to OIDC authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,10 @@ jobs:
       - build_test
       - cypress
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      deployments: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -76,13 +80,15 @@ jobs:
           # skip installing cypress since it isn't needed for just building
           # This decreases the deploy time quite a bit
           CYPRESS_INSTALL_BINARY: 0
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::612297603577:role/dst-codap-plugin
+          aws-region: us-east-1
       - uses: concord-consortium/s3-deploy-action@v1
         id: s3-deploy
         with:
           bucket: models-resources
           prefix: dst-codap-plugin
-          awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          awsSecretAccessKey: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           deployRunUrl: https://codap3.concord.org/branch/main/?di=https://models-resources.concord.org/dst-codap-plugin/__deployPath__/index.html
           # Parameters to GHActions have to be strings, so a regular yaml array cannot

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,6 +7,10 @@ jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
@@ -28,12 +32,14 @@ jobs:
     - uses: concord-consortium/s3-deploy-action/deploy-path@v1
       if: always()
       id: s3-deploy-path
+    - uses: aws-actions/configure-aws-credentials@v6
+      if: always()
+      with:
+        role-to-assume: arn:aws:iam::612297603577:role/dst-codap-plugin
+        aws-region: us-east-1
     - name: Upload Playwright Report
       if: always()
       run: aws s3 sync ./playwright-report s3://models-resources/dst-codap-plugin/playwright-report/${{ steps.s3-deploy-path.outputs.deployPath }} --delete --cache-control "no-cache, max-age=0"
-      env: 
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
     # This report summary action only works when it is run during a pull_request event. It uses 
     # the info from the event to figure out what PR to add/update the comment on. At some point 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is a bare-bones React project, created with the `--typescript` version of [Create React App](https://github.com/facebook/create-react-app), and left un-ejected. This is simply a trivial React view with the libraries for using the [CODAP Plugin API](https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-Plugin-API).
 
+## Deployment
+
+S3 deployment is handled by GitHub Actions using OIDC for AWS authentication. See [deploy-setup.md in starter-projects](https://github.com/concord-consortium/starter-projects/blob/main/doc/deploy-setup.md) for how the AWS side is set up, and [doc/deploy.md](doc/deploy.md) for how deploys work in this repo.
+
 ## Development
 
 ### Initial steps

--- a/doc/deploy.md
+++ b/doc/deploy.md
@@ -1,0 +1,19 @@
+# Deployment
+
+S3 deployment is handled by GitHub Actions. Pushes are deployed under
+`models-resources/dst-codap-plugin/` (e.g. `branch/<name>/...`) by the `s3-deploy` job in
+[`ci.yml`](../.github/workflows/ci.yml). The Playwright test report is uploaded to
+`models-resources/dst-codap-plugin/playwright-report/...` by
+[`playwright.yml`](../.github/workflows/playwright.yml).
+
+## AWS Access
+
+The GitHub Actions workflows in this project are allowed to update files in S3 using OIDC.
+An IAM role has been created in AWS with a trust policy that allows GitHub Actions in
+this specific repository to assume this IAM role. The IAM role has a `RepoName` tag
+and a managed policy that uses this tag to give the role permission to update files under
+`s3://models-resources/dst-codap-plugin/`.
+
+See
+[deploy-setup.md in starter-projects](https://github.com/concord-consortium/starter-projects/blob/main/doc/deploy-setup.md)
+for how the AWS side is set up.


### PR DESCRIPTION
[DEV-163](https://concord-consortium.atlassian.net/browse/DEV-163)

Replace static AWS access-key secrets with OIDC role assumption in the S3 deploy workflows. `ci.yml` s3-deploy plus `playwright.yml` (its Playwright-report upload runs a raw `aws s3 sync`; added an `if: always()` credentials step so the upload keeps creds even when tests fail); `doc/deploy.md` + `README` reference added.

[DEV-163]: https://concord-consortium.atlassian.net/browse/DEV-163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ