### PR TITLE
Update Playwright test for CODAP v3 case-table test id rename

### DIFF
--- a/playwright/in-codap.spec.ts
+++ b/playwright/in-codap.spec.ts
@@ -5,15 +5,6 @@ test("Test app inside of CODAP", async ({ page }) => {
   await page.setViewportSize({width: 1400, height: 800});
   await page.goto("https://codap3.concord.org/?mouseSensor&di=https://localhost:8080");
 
-  // Move the table over 80 pixels so it doesn't overlap with the plugin
-  const table = page.getByTestId("codap-case-table");
-  await table.hover({ position: { x: 3, y: 3 } });
-  const box = await table.boundingBox() || {x: 0, y: 0};
-  await page.mouse.down();
-  await page.mouse.move(box.x + 83, box.y + 3);
-  await page.mouse.move(box.x + 83, box.y + 3);
-  await page.mouse.up();
-
   const iframe = page.frameLocator(".codap-web-view-iframe");
   const firstLegendArea = iframe.getByText("To create a Color Legend");
   await firstLegendArea.click();


### PR DESCRIPTION
In a previous version of CODAP, a case table was auto-opened when the plugin created its data context. Since that table overlapped the plugin, a Playwright test used to drag the table aside as a first step. CODAP v3 no longer auto-opens a case table, so the Playwright test was failing when it tried to find the table. To fix that, this PR simply removes the case table-related code from the test.